### PR TITLE
Issue 37

### DIFF
--- a/flama/applications.py
+++ b/flama/applications.py
@@ -101,26 +101,14 @@ class Flama(Starlette, SchemaMixin):
         **request_schemas: typing.Dict[str, marshmallow.Schema]
     ) -> typing.Callable:
         def decorator(func: typing.Callable) -> typing.Callable:
-            # If @schemas is used, it has precedence
-            # i.e.:
-            # @app.route('/', arg1: FooSchema)
-            # @app.schemas('/', arg2: BarSchema, response_schema=FooBarSchema)
-            # def endpoint(arg1, arg2):
-            #       pass
-            if getattr(func, '_request_schemas', None):
-                merged_schemas = request_schemas.copy()
-                merged_schemas.update(func._request_schemas)
-                func._request_schemas = merged_schemas
-            else:
-                func._request_schemas = request_schemas
-            func._response_schema = response_schema if getattr(func, '_response_schema', None) is None else func._response_schema
-
             self.router.add_route(
                 path,
                 func,
                 methods=methods,
                 name=name,
                 include_in_schema=include_in_schema,
+                response_schema=response_schema,
+                request_schemas=request_schemas,
             )
             return func
 

--- a/flama/applications.py
+++ b/flama/applications.py
@@ -101,8 +101,19 @@ class Flama(Starlette, SchemaMixin):
         **request_schemas: typing.Dict[str, marshmallow.Schema]
     ) -> typing.Callable:
         def decorator(func: typing.Callable) -> typing.Callable:
-            func._request_schemas = request_schemas
-            func._response_schema = response_schema
+            # If @schemas is used, it has precedence
+            # i.e.:
+            # @app.route('/', arg1: FooSchema)
+            # @app.schemas('/', arg2: BarSchema, response_schema=FooBarSchema)
+            # def endpoint(arg1, arg2):
+            #       pass
+            if getattr(func, '_request_schemas', None):
+                merged_schemas = request_schemas.copy()
+                merged_schemas.update(func._request_schemas)
+                func._request_schemas = merged_schemas
+            else:
+                func._request_schemas = request_schemas
+            func._response_schema = response_schema if getattr(func, '_response_schema', None) is None else func._response_schema
 
             self.router.add_route(
                 path,

--- a/flama/components/validation.py
+++ b/flama/components/validation.py
@@ -1,9 +1,9 @@
+import typing
+
 import datetime
 import inspect
-import typing
-import uuid
-
 import marshmallow
+import uuid
 from starlette import status
 
 from flama import codecs, exceptions, http, websockets
@@ -12,6 +12,7 @@ from flama.exceptions import WebSocketException
 from flama.negotiation import ContentTypeNegotiator, WebSocketEncodingNegotiator
 from flama.routing import Route
 from flama.types import OptBool, OptDate, OptDateTime, OptFloat, OptInt, OptStr, OptUUID
+from flama.utils import is_marshmallow_dataclass, is_marshmallow_schema
 
 ValidatedPathParams = typing.NewType("ValidatedPathParams", dict)
 ValidatedQueryParams = typing.NewType("ValidatedQueryParams", dict)
@@ -158,7 +159,7 @@ class PrimitiveParamComponent(Component):
 
 class CompositeParamComponent(Component):
     def can_handle_parameter(self, parameter: inspect.Parameter):
-        return inspect.isclass(parameter.annotation) and issubclass(parameter.annotation, marshmallow.Schema)
+        return is_marshmallow_schema(parameter.annotation) or is_marshmallow_dataclass(parameter.annotation)
 
     def resolve(self, parameter: inspect.Parameter, data: ValidatedRequestData):
         return data

--- a/flama/endpoints.py
+++ b/flama/endpoints.py
@@ -1,5 +1,4 @@
 import asyncio
-
 from starlette import status
 from starlette.concurrency import run_in_threadpool
 from starlette.endpoints import HTTPEndpoint as BaseHTTPEndpoint
@@ -8,7 +7,7 @@ from starlette.requests import Request
 from starlette.websockets import WebSocket, WebSocketState
 
 from flama import exceptions, websockets
-from flama.responses import APIResponse
+from flama.responses import APIResponse, Response
 from flama.validation import get_output_schema
 
 __all__ = ["HTTPEndpoint", "WebSocketEndpoint"]
@@ -47,6 +46,10 @@ class HTTPEndpoint(BaseHTTPEndpoint):
             response = APIResponse(content=response)
         elif response is None:
             response = APIResponse(content="")
+        elif not isinstance(response, Response):
+            schema = get_output_schema(handler)
+            if schema is not None:
+                response = APIResponse(content=response, schema=get_output_schema(handler))
 
         await response(self.scope, self.receive, self.send)
 

--- a/flama/routing.py
+++ b/flama/routing.py
@@ -12,7 +12,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from flama import http, websockets
 from flama.components import Component
-from flama.responses import APIResponse
+from flama.responses import APIResponse, Response
 from flama.types import Field, FieldLocation, HTTPMethod, OptBool, OptFloat, OptInt, OptStr
 from flama.utils import is_marshmallow_dataclass, is_marshmallow_schema
 from flama.validation import get_output_schema
@@ -195,6 +195,10 @@ class Route(starlette.routing.Route, FieldsMixin):
                     response = APIResponse(content=response)
                 elif response is None:
                     response = APIResponse(content="")
+                elif not isinstance(response, Response):
+                    schema = get_output_schema(endpoint)
+                    if schema is not None:
+                        response = APIResponse(content=response, schema=get_output_schema(endpoint))
             except Exception:
                 logger.exception("Error building response")
                 raise

--- a/flama/routing.py
+++ b/flama/routing.py
@@ -311,10 +311,24 @@ class Router(starlette.routing.Router):
         self.routes.append(route)
 
     def route(
-        self, path: str, methods: typing.List[str] = None, name: str = None, include_in_schema: bool = True
+        self,
+        path: str,
+        methods: typing.List[str] = None,
+        name: str = None,
+        include_in_schema: bool = True,
+        response_schema: marshmallow.Schema = None,
+        request_schemas: typing.Dict[str, marshmallow.Schema] = None,
     ) -> typing.Callable:
         def decorator(func: typing.Callable) -> typing.Callable:
-            self.add_route(path, func, methods=methods, name=name, include_in_schema=include_in_schema)
+            self.add_route(
+                path,
+                func,
+                methods=methods,
+                name=name,
+                include_in_schema=include_in_schema,
+                response_schema=response_schema,
+                request_schemas=request_schemas
+            )
             return func
 
         return decorator

--- a/flama/utils.py
+++ b/flama/utils.py
@@ -1,5 +1,9 @@
 import typing
 
+import inspect
+import marshmallow
+from dataclasses import is_dataclass
+
 __all__ = ["dict_safe_add"]
 
 
@@ -13,3 +17,11 @@ def dict_safe_add(d: typing.Dict, v: typing.Any, *keys):
         _d = _d[k]
 
     _d[keys[-1]] = v
+
+
+def is_marshmallow_schema(obj):
+    return inspect.isclass(obj) and issubclass(obj, marshmallow.Schema)
+
+
+def is_marshmallow_dataclass(obj):
+    return is_dataclass(obj) and hasattr(obj, 'Schema') and is_marshmallow_schema(obj.Schema)

--- a/flama/validation.py
+++ b/flama/validation.py
@@ -4,6 +4,7 @@ import marshmallow
 from functools import wraps
 
 from flama import exceptions
+from flama.utils import is_marshmallow_dataclass, is_marshmallow_schema
 
 __all__ = ["get_output_schema", "output_validation"]
 
@@ -17,8 +18,10 @@ def get_output_schema(func):
     """
     response_schema = getattr(func, '_response_schema', None)
     return_annotation = response_schema if response_schema else inspect.signature(func).return_annotation
-    if inspect.isclass(return_annotation) and issubclass(return_annotation, marshmallow.Schema):
+    if is_marshmallow_schema(return_annotation):
         return return_annotation()
+    elif is_marshmallow_dataclass(return_annotation):
+        return return_annotation.Schema()
     elif isinstance(return_annotation, marshmallow.Schema):
         return return_annotation
 

--- a/flama/validation.py
+++ b/flama/validation.py
@@ -1,8 +1,7 @@
 import asyncio
 import inspect
-from functools import wraps
-
 import marshmallow
+from functools import wraps
 
 from flama import exceptions
 
@@ -16,7 +15,8 @@ def get_output_schema(func):
     :param func: Annotated function.
     :returns: Output schema.
     """
-    return_annotation = inspect.signature(func).return_annotation
+    response_schema = getattr(func, '_response_schema', None)
+    return_annotation = response_schema if response_schema else inspect.signature(func).return_annotation
     if inspect.isclass(return_annotation) and issubclass(return_annotation, marshmallow.Schema):
         return return_annotation()
     elif isinstance(return_annotation, marshmallow.Schema):


### PR DESCRIPTION
Resolves #37 
Tested with:

```python
import logging
from dataclasses import dataclass

import marshmallow as ma
import marshmallow.fields as mf
from flama import Flama
from marshmallow_dataclass import dataclass as ma_dataclass

logger = logging.getLogger(__name__)

# Application
app = Flama(
    components=[],      # Without custom components
    title="Foo",        # API title
    version="0.1",      # API version
    description="Bar",  # API description
    schema="/schema/",  # Path to expose OpenAPI schema
    docs="/docs/",      # Path to expose Swagger UI docs
    redoc="/redoc/",    # Path to expose ReDoc docs
)


@ma_dataclass
class Foo2:
    foo: str
    bar: int


@dataclass
class Foo:
    foo: str
    bar: int


class FooSchema(ma.Schema):
    foo = mf.String()
    bar = mf.Integer(missing=2)
    foobar = mf.String(default='foobar', missing='foobar')

    @ma.post_load
    def make_object(self, data, **kwargs):
        return Foo(**data)


@app.route('/1', methods=['GET'], data=FooSchema, response_schema=FooSchema)
def endpoint(data: Foo) -> Foo:
    logger.info(f'{type(data)} - {data}')
    return data


@app.route('/2', methods=['GET'])
@app.schemas(data=FooSchema, response_schema=FooSchema)
def endpoint2(data: Foo) -> Foo:
    logger.info(f'{type(data)} - {data}')
    return data


@app.route('/3', methods=['GET'])
def endpoint3(data: Foo2) -> Foo2:
    logger.info(f'{type(data)} - {data}')
    return data


@app.route('/4', methods=['GET'], response_schema=FooSchema)
def endpoint4(data: Foo2) -> Foo2:
    logger.info(f'{type(data)} - {data}')
    return data

```