### PR TITLE
:construction_worker: Cache shared CI work and fix release annotations

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,8 +1,9 @@
 name: Setup
 description: >
-  Set up the Flama toolchain (Node, uv, Rust) and install the project. When GCP
-  Workload Identity Federation credentials are provided, templates are built from
-  the private @vortico/ui registry; otherwise the public template path is used.
+  Set up the Flama toolchain (uv, Rust, and Node only when templates are built) and install the
+  project. Templates can be built from the private @vortico/ui registry (GCP WIF), fetched from a
+  published wheel (public path), or skipped entirely when the caller already provides
+  flama/_templates (e.g. a downloaded artifact).
 
 inputs:
   python-version:
@@ -20,16 +21,40 @@ inputs:
     description: Build the Rust extension in release mode (required for meaningful performance numbers).
     required: false
     default: "false"
+  templates:
+    description: >
+      Template handling: 'auto' (build when GCP creds are present, else fetch from a published wheel),
+      'build', 'fetch', or 'skip' (the caller already placed flama/_templates, e.g. via a downloaded
+      artifact). 'skip' and 'fetch' do not set up Node.
+    required: false
+    default: "auto"
 
 runs:
   using: composite
   steps:
+    # Collapse 'auto' into a concrete mode (build/fetch) once, so the steps below stay simple.
+    - name: Resolve templates mode
+      id: tpl
+      shell: bash
+      env:
+        MODE: ${{ inputs.templates }}
+        HAS_CREDS: ${{ inputs.gcp-workload-identity-provider != '' && inputs.gcp-service-account != '' }}
+      run: |
+        mode="$MODE"
+        if [[ "$mode" == "auto" ]]; then
+          if [[ "$HAS_CREDS" == "true" ]]; then mode="build"; else mode="fetch"; fi
+        fi
+        echo "mode=$mode" >> "$GITHUB_OUTPUT"
+
+    # Node is only needed to build templates from source; fetch/skip don't need it.
     - name: Set up Node
+      if: ${{ steps.tpl.outputs.mode == 'build' }}
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 22
 
     - name: Enable Corepack
+      if: ${{ steps.tpl.outputs.mode == 'build' }}
       shell: bash
       run: corepack enable
 
@@ -39,6 +64,9 @@ runs:
         python-version: ${{ inputs.python-version }}
         enable-cache: true
         cache-dependency-glob: "uv.lock"
+        # Per-job suffix so the jobs that share this composite action (test/performance/benchmark) and
+        # the standalone `checks` job don't race to save the same per-Python uv cache key.
+        cache-suffix: ${{ github.job }}
 
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -48,26 +76,31 @@ runs:
       with:
         workspaces: lib/core
 
-    # Core-team / same-repo runs authenticate via Workload Identity Federation to build the
-    # private @vortico/ui templates. Fork PRs (and any repo without these secrets) get no
-    # OIDC token, so they fall back to the public template path below instead of failing.
+    # Build path: authenticate to GCP (WIF) and build the private @vortico/ui templates.
     - name: Authenticate to Google Cloud
-      if: ${{ inputs.gcp-workload-identity-provider != '' && inputs.gcp-service-account != '' }}
+      if: ${{ steps.tpl.outputs.mode == 'build' }}
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
       with:
         workload_identity_provider: ${{ inputs.gcp-workload-identity-provider }}
         service_account: ${{ inputs.gcp-service-account }}
 
     - name: Set up Cloud SDK
-      if: ${{ inputs.gcp-workload-identity-provider != '' && inputs.gcp-service-account != '' }}
+      if: ${{ steps.tpl.outputs.mode == 'build' }}
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
-    - name: Install project (private templates)
-      if: ${{ inputs.gcp-workload-identity-provider != '' && inputs.gcp-service-account != '' }}
+    - name: Install project (build templates)
+      if: ${{ steps.tpl.outputs.mode == 'build' }}
       shell: bash
       run: ./scripts/install --build-templates ${{ inputs.release == 'true' && '--release' || '' }}
 
-    - name: Install project (public templates)
-      if: ${{ inputs.gcp-workload-identity-provider == '' || inputs.gcp-service-account == '' }}
+    # Fetch path: download prebuilt templates from a published wheel (fork PRs / no creds).
+    - name: Install project (fetch templates)
+      if: ${{ steps.tpl.outputs.mode == 'fetch' }}
       shell: bash
       run: ./scripts/install --fetch-templates ${{ inputs.release == 'true' && '--release' || '' }}
+
+    # Skip path: the caller already placed flama/_templates (e.g. a downloaded artifact).
+    - name: Install project (templates already provided)
+      if: ${{ steps.tpl.outputs.mode == 'skip' }}
+      shell: bash
+      run: ./scripts/install --no-build-templates ${{ inputs.release == 'true' && '--release' || '' }}

--- a/.github/workflows/ci_production.yaml
+++ b/.github/workflows/ci_production.yaml
@@ -40,6 +40,41 @@ jobs:
     name: Config
     uses: ./.github/workflows/_python-versions.yaml
 
+  templates:
+    name: Templates
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      available: ${{ steps.mark.outputs.available }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      # Build the private @vortico/ui templates once; every test/wheel/sdist/benchmark job downloads
+      # this artifact instead of rebuilding (templates are arch-independent web assets).
+      - name: Build templates
+        id: build
+        uses: ./.github/actions/build-templates
+        with:
+          gcp-workload-identity-provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Upload templates
+        if: ${{ steps.build.outcome == 'success' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: templates
+          path: flama/_templates
+          if-no-files-found: error
+          retention-days: 1
+
+      - id: mark
+        shell: bash
+        run: echo "available=${{ steps.build.outcome == 'success' }}" >> "$GITHUB_OUTPUT"
+
   checks:
     name: Checks (${{ matrix.python }})
     needs: [config]
@@ -59,11 +94,19 @@ jobs:
           python-version: ${{ matrix.python }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          # Per-job suffix: `checks` and `test` build the same per-Python uv cache and would otherwise
+          # race to save the same key (the "Unable to reserve cache" warning). Distinct suffixes split
+          # them cleanly.
+          cache-suffix: ${{ github.job }}
 
+      # Only the typecheck step (>= 3.13) builds the Rust extension; format/lint run via `uvx ruff`
+      # and need no toolchain. Skip Rust setup/cache on the other rows.
       - name: Set up Rust
+        if: matrix.python >= '3.13'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache Rust
+        if: matrix.python >= '3.13'
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: lib/core
@@ -80,7 +123,7 @@ jobs:
 
   test:
     name: Test (${{ matrix.python }})
-    needs: [config]
+    needs: [config, templates]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -94,12 +137,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
+      - name: Download templates
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: templates
+          path: flama/_templates
+
       - name: Set up project
         uses: ./.github/actions/setup
         with:
           python-version: ${{ matrix.python }}
           gcp-workload-identity-provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          # Reuse the prebuilt templates artifact (push to master is always same-repo).
+          templates: "skip"
 
       - name: Tests
         run: ./scripts/test
@@ -129,7 +180,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout
@@ -188,7 +239,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout
@@ -206,6 +257,8 @@ jobs:
           gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           # Measure an optimized _core; a debug build would make instruction counts meaningless.
           release: "true"
+          # The benchmarks don't render docs pages, so skip templates entirely (no Node/pnpm build).
+          templates: "skip"
 
       - name: Install Valgrind
         # The runner image does not ship Valgrind. Try a direct install first (the image's apt cache is
@@ -233,7 +286,7 @@ jobs:
 
   build-wheels:
     name: Build wheels (${{ matrix.name }})
-    needs: [release, config]
+    needs: [release, config, templates]
     if: needs.release.outputs.published == 'true'
     strategy:
       fail-fast: false
@@ -286,13 +339,13 @@ jobs:
         with:
           python-version: ${{ steps.interp.outputs.lines }}
 
-      # Release artifacts must bundle the real @vortico/ui templates; this path is strict
-      # (no public fallback).
-      - name: Build templates
-        uses: ./.github/actions/build-templates
+      # Release artifacts must bundle the real @vortico/ui templates; reuse the prebuilt artifact from
+      # the `templates` job instead of rebuilding here.
+      - name: Download templates
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          gcp-workload-identity-provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          name: templates
+          path: flama/_templates
 
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
@@ -300,6 +353,9 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist ${{ steps.interp.outputs.args }}
           manylinux: ${{ matrix.manylinux }}
+          # Cache Rust compilation across releases (this is the only heavy Rust consumer with no cache;
+          # the emulated aarch64/musl rows dominate release time). sccache uses the GitHub Actions cache.
+          sccache: "true"
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -309,7 +365,7 @@ jobs:
 
   build-sdist:
     name: Build sdist
-    needs: [release]
+    needs: [release, templates]
     if: needs.release.outputs.published == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -322,13 +378,13 @@ jobs:
         with:
           ref: master
 
-      # Release artifacts must bundle the real @vortico/ui templates; this path is strict
-      # (no public fallback). A push to master always runs with the org GCP secrets available.
-      - name: Build templates
-        uses: ./.github/actions/build-templates
+      # Release artifacts must bundle the real @vortico/ui templates; reuse the prebuilt artifact from
+      # the `templates` job instead of rebuilding here.
+      - name: Download templates
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          gcp-workload-identity-provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          name: templates
+          path: flama/_templates
 
       - name: Build sdist
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
@@ -349,27 +405,36 @@ jobs:
     timeout-minutes: 15
     environment: pypi
     permissions:
+      contents: read
       id-token: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: master
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist/
           merge-multiple: true
 
+      # `uv publish` uses PyPI Trusted Publishing (OIDC) via the `pypi` environment + id-token; the
+      # PyPI trusted-publisher config (workflow file + environment) is unchanged from the previous
+      # maturin upload, so no PyPI-side change is needed.
       - name: Publish to PyPI
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
-        with:
-          command: upload
-          args: --non-interactive --skip-existing dist/*
+        run: ./scripts/publish
 
   docker_push:
     name: Docker Push (${{ matrix.linux }}, ${{ matrix.python }}, ${{ matrix.schemas }})
     needs: [release, publish, config]
     if: needs.release.outputs.published == 'true'
-    environment:
-      name: dockerhub
-      url: https://hub.docker.com/r/vortico/flama
+    # No environment `url:` here on purpose: the `dockerhub` environment holds secrets, so GitHub
+    # refuses to publish a URL for it and warns on every matrix job. The link added nothing.
+    environment: dockerhub
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -428,3 +493,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Run-over-run layer cache, scoped per tag combination so the 15 matrix builds don't clobber
+          # each other's cache. Helps most with the emulated arm64 layers.
+          cache-from: type=gha,scope=${{ matrix.linux }}-${{ matrix.python }}-${{ matrix.schemas }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.linux }}-${{ matrix.python }}-${{ matrix.schemas }}

--- a/.github/workflows/ci_pull_request.yaml
+++ b/.github/workflows/ci_pull_request.yaml
@@ -53,12 +53,52 @@ jobs:
           # The performance suite is slow, so run it only when something that can move the numbers
           # changes: the framework, the Rust core, the perf tests/harness, or the locked dependency set.
           # Docs/examples/CI-only PRs skip it.
-          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" |
+          #
+          # Three-dot (merge-base) diff: only count what THIS PR changed, not commits that landed on
+          # master after the branch point. A two-dot diff would otherwise flag pyproject.toml/uv.lock
+          # whenever the branch is merely behind a release and re-run the whole suite for nothing.
+          if git diff --name-only "$BASE_SHA...$HEAD_SHA" |
             grep -qE '^(flama/|lib/|tests/performance/|scripts/performance$|scripts/benchmark$|pyproject\.toml$|uv\.lock$)'; then
             echo "performance=true" >> "$GITHUB_OUTPUT"
           else
             echo "performance=false" >> "$GITHUB_OUTPUT"
           fi
+
+  templates:
+    name: Templates
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      # 'true' only when the artifact was built+uploaded (same-repo). Fork PRs skip the build, so
+      # consumers fall back to fetching prebuilt templates from a published wheel.
+      available: ${{ steps.mark.outputs.available }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Build templates
+        id: build
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: ./.github/actions/build-templates
+        with:
+          gcp-workload-identity-provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Upload templates
+        if: ${{ steps.build.outcome == 'success' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: templates
+          path: flama/_templates
+          if-no-files-found: error
+          retention-days: 1
+
+      - id: mark
+        shell: bash
+        run: echo "available=${{ steps.build.outcome == 'success' }}" >> "$GITHUB_OUTPUT"
 
   checks:
     name: Checks (${{ matrix.python }})
@@ -79,11 +119,19 @@ jobs:
           python-version: ${{ matrix.python }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          # Per-job suffix: `checks` and `test` build the same per-Python uv cache and would otherwise
+          # race to save the same key (the "Unable to reserve cache" warning). Distinct suffixes split
+          # them cleanly.
+          cache-suffix: ${{ github.job }}
 
+      # Only the typecheck step (>= 3.13) builds the Rust extension; format/lint run via `uvx ruff`
+      # and need no toolchain. Skip Rust setup/cache on the other rows.
       - name: Set up Rust
+        if: matrix.python >= '3.13'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache Rust
+        if: matrix.python >= '3.13'
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: lib/core
@@ -108,7 +156,7 @@ jobs:
 
   test:
     name: Test (${{ matrix.python }})
-    needs: [config]
+    needs: [config, templates]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -122,12 +170,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
+      - name: Download templates
+        if: ${{ needs.templates.outputs.available == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: templates
+          path: flama/_templates
+
       - name: Set up project
         uses: ./.github/actions/setup
         with:
           python-version: ${{ matrix.python }}
           gcp-workload-identity-provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          # Reuse the prebuilt templates artifact when available; fork PRs fetch from a published wheel.
+          templates: ${{ needs.templates.outputs.available == 'true' && 'skip' || 'fetch' }}
 
       - id: tests
         name: Tests
@@ -163,6 +220,8 @@ jobs:
           gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           # Measure an optimized _core; a debug build would make instruction counts meaningless.
           release: "true"
+          # The benchmarks don't render docs pages, so skip templates entirely (no Node/pnpm build).
+          templates: "skip"
 
       - name: Install Valgrind
         # The runner image does not ship Valgrind. Try a direct install first (the image's apt cache is
@@ -190,7 +249,7 @@ jobs:
   ci:
     name: CI
     if: always()
-    needs: [commitlint, config, changes, checks, test, performance]
+    needs: [commitlint, config, changes, templates, checks, test, performance]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -218,7 +277,10 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      # Only when the performance job ran and produced the artifact. Attempting the download on PRs
+      # where performance was skipped just emits a noisy "artifact not found" warning.
       - name: Download performance comparison
+        if: needs.performance.result == 'success'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: performance-comparison

--- a/scripts/publish
+++ b/scripts/publish
@@ -5,15 +5,37 @@ source "./scripts/clean"
 source "./scripts/build"
 
 # ─── Publish ─────────────────────────────────────────────────────────────────
+#
+# Uploads distributions with `uv publish`. In CI this relies on PyPI Trusted Publishing
+# (OIDC) — uv detects the GitHub Actions environment automatically, so no token is needed.
+# `--check-url` makes re-runs idempotent by skipping artifacts already present on the index
+# (the replacement for maturin's deprecated `upload --skip-existing`).
+#
+# Usage:
+#   ./scripts/publish                 Upload pre-built artifacts (default: dist/*)
+#   ./scripts/publish PATH...         Upload the given files/globs
+#   ./scripts/publish --build         Clean, build (host wheel + templates), then upload target/wheels/*
 
 run_publish() {
-  if [[ "$1" == "--build" ]]; then
+  local build=false
+  local paths=()
+  for arg in "$@"; do
+    case "$arg" in
+    --build) build=true ;;
+    *) paths+=("$arg") ;;
+    esac
+  done
+
+  if $build; then
     run_clean
     run_build --build-templates
+    [[ ${#paths[@]} -eq 0 ]] && paths=(target/wheels/*)
   fi
 
+  [[ ${#paths[@]} -eq 0 ]] && paths=(dist/*)
+
   echo "📤 Publishing package..."
-  uv run maturin publish
+  uv publish --check-url https://pypi.org/simple/flama/ "${paths[@]}"
   echo "✅ Publish complete."
 }
 


### PR DESCRIPTION
## Summary

CI performance + the 5 non-fatal Production annotations, in one pass.

### Caching / dedup
- **Templates built once**: a new `templates` job builds `flama/_templates` once and uploads it as an artifact; `test`, `build-wheels`, and `build-sdist` download it instead of rebuilding (Node/pnpm/webpack ran ~14x/release). `performance` and `benchmark` skip templates entirely (not needed by the benchmarks). Fork PRs fall back to `--fetch-templates`.
- **Setup action** gains a `templates: build|fetch|skip|auto` input and only sets up Node when actually building templates.
- **sccache** on the `build-wheels` maturin step (the only heavy Rust consumer with no cache; the emulated aarch64/musl rows dominate release time).
- **Docker layer cache** (`type=gha`, scoped per tag) on the 15-way image matrix.
- **Per-job uv `cache-suffix`** so `checks` and `test` stop racing on the same key (clears the "unable to reserve cache" warnings).
- **Checks Rust gating**: only the typecheck rows (>= 3.13) set up Rust/cache.

### Annotation fixes
- PyPI publish routed through `scripts/publish` using `uv publish` (OIDC trusted publishing, `--check-url` for idempotent re-runs), replacing the deprecated `maturin upload`.
- Dropped the `dockerhub` environment `url:` (removes the "may contain secret" warning on every matrix job).
- `setup-python` is already at latest (v6.2.0); the macOS arm64 "cache deserialization" line is a transient GitHub cache-service warning, left to self-heal.