### PR TITLE
:lock: Safe path check in deserialization

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,6 +10,18 @@ running the most recent version of Flama.
 | 2.x     | :white_check_mark: |
 | < 2.0   | :x:                |
 
+## Loading model artifacts
+
+Deserialising a `.flm` artifact executes code from that artifact. The model section is handed
+to the framework that produced it, and for several of the supported frameworks that means
+unpickling: `pickle` and `torch` payloads can run arbitrary code as soon as the model is
+materialised. This is inherent to the underlying formats, not a defect Flama can patch away.
+
+Treat a `.flm` file exactly as you would treat a pickle: **only load artifacts from sources you
+trust**. Loading a model downloaded from an untrusted or unverified location is equivalent to
+running that publisher's code on your machine, regardless of any hardening in the serialisation
+layer.
+
 ## Reporting a vulnerability
 
 Please **do not** report security vulnerabilities through public GitHub issues,

--- a/flama/_cli/commands/get.py
+++ b/flama/_cli/commands/get.py
@@ -23,6 +23,7 @@ from rich.progress import (
 from flama import concurrency, types
 from flama._cli.formatting import CONSOLE, FlamaCommand
 from flama.client import Client
+from flama.serialize.exceptions import UnsafeArtifactPath
 from flama.serialize.serializer import Serializer
 
 __all__ = ["get", "command"]
@@ -179,8 +180,20 @@ class _HuggingFaceDownloader(_Downloader):
                 task.result()
 
     async def _download_file(self, filename: str, progress: Progress, progress_id: TaskID) -> None:
+        """Stage *filename* under the download directory, refusing names that escape it.
+
+        Remote file names come from the source's own API listing, so they are attacker-controlled
+        for any third-party repository; the resolved destination is confined to the staging root
+        (``CWE-22``).
+
+        :raises UnsafeArtifactPath: When *filename* resolves outside the staging directory.
+        """
         async with self.semaphore:
-            dest = pathlib.Path(self.tmp.name) / filename
+            root = pathlib.Path(self.tmp.name).resolve()
+            dest = (root / filename).resolve()
+            if not dest.is_relative_to(root):
+                raise UnsafeArtifactPath(filename)
+
             await concurrency.run(dest.parent.mkdir, parents=True, exist_ok=True)
             await self.retry(lambda: self._stream_to_file(filename, dest, progress, progress_id))
 

--- a/flama/serialize/exceptions.py
+++ b/flama/serialize/exceptions.py
@@ -5,6 +5,8 @@ __all__ = [
     "UnknownCompression",
     "UnknownModelCapabilities",
     "UnknownModelKind",
+    "UnsafeArtifactName",
+    "UnsafeArtifactPath",
     "UnsupportedProtocol",
 ]
 
@@ -72,6 +74,34 @@ class UnknownCompression(ModelArtifactError):
         self.value = value
         rendered = f"0x{value:02x}" if isinstance(value, int) and value >= 0 else repr(value)
         super().__init__(rendered, "is not a known compression format")
+
+
+class UnsafeArtifactName(ModelArtifactError):
+    """A bundled artifact name cannot be safely materialised on disk.
+
+    Artifact names travel verbatim inside a ``.flm`` body, so a hostile file could otherwise name an
+    absolute path or a ``..`` traversal segment and have extraction write anywhere the loading
+    process can reach (``CWE-22``, "zip-slip"). Raised by
+    :meth:`~flama.serialize.protocols._base.BaseProtocol.artifact_name` on both the pack and the
+    unpack side, so a malformed name is refused when a ``.flm`` is written as well as when it is
+    read.
+    """
+
+    def __init__(self, name: str) -> None:
+        super().__init__(repr(name), "is not a safe artifact name")
+
+
+class UnsafeArtifactPath(ModelArtifactError):
+    """A staged artifact file resolves outside its destination directory.
+
+    Raised while assembling an artifact from a remote source, where file names come from the
+    source's own listing and are therefore attacker-controlled for any third-party repository.
+    Unlike :class:`UnsafeArtifactName`, nested names are legitimate here, so the invariant is
+    containment within the destination root rather than a single path component.
+    """
+
+    def __init__(self, name: str) -> None:
+        super().__init__(repr(name), "resolves outside the destination directory")
 
 
 class UnsupportedProtocol(ModelArtifactError):

--- a/flama/serialize/protocols/_base.py
+++ b/flama/serialize/protocols/_base.py
@@ -1,9 +1,11 @@
 import abc
 import importlib
+import pathlib
 import typing as t
 
 from flama import types
 from flama.serialize.data_structures import Metadata, ModelArtifact
+from flama.serialize.exceptions import UnsafeArtifactName
 
 __all__ = ["BaseProtocol", "Protocol"]
 
@@ -12,6 +14,36 @@ class BaseProtocol(abc.ABC):
     """Base class for defining a serialization protocol for ML models."""
 
     lib: t.ClassVar[types.ModelLib]
+
+    @staticmethod
+    def artifact_name(name: str, /) -> str:
+        """Validate a bundled artifact *name* against the wire format's naming contract.
+
+        Only a single plain file name is accepted: absolute, nested, drive-qualified, traversal and
+        empty names are all refused, so an artifact read from an untrusted ``.flm`` can never be
+        materialised outside its extraction directory (``CWE-22``). Names are checked under both
+        POSIX and Windows semantics, so an artifact written on one platform cannot escape on the
+        other, and the relative directory names are rejected up front because :mod:`pathlib` keeps
+        ``".."`` as an ordinary final component rather than normalising it away.
+
+        Restricting to a single component also keeps
+        :data:`~flama.serialize.data_structures.Artifacts` unambiguously keyed, as every protocol
+        keys the unpacked mapping by file name.
+
+        :param name: Artifact name as decoded from, or destined for, the wire format.
+        :return: The validated name, unchanged.
+        :raises UnsafeArtifactName: When *name* is not a plain file name.
+        """
+        if (
+            not name
+            or name in {".", ".."}
+            or "\x00" in name
+            or name != pathlib.PurePosixPath(name).name
+            or name != pathlib.PureWindowsPath(name).name
+        ):
+            raise UnsafeArtifactName(name)
+
+        return name
 
     @abc.abstractmethod
     def dump(self, m: ModelArtifact, f: t.BinaryIO, /, *, compression: types.SerializationCompression, **kwargs) -> int:

--- a/flama/serialize/protocols/v1.py
+++ b/flama/serialize/protocols/v1.py
@@ -20,7 +20,7 @@ Wire layout::
         artifact * count
             name_size          I
             content_size       Q
-            name               utf-8 bytes
+            name               utf-8 bytes (a single plain file name)
             content            compressed payload bytes
 
 v1 stays available so older ``.flm`` files keep loading; the
@@ -53,6 +53,8 @@ class _Artifact:
 
     @classmethod
     def pack(cls, name: str, path: pathlib.Path, /, *, compression: types.SerializationCompression, **kwargs) -> bytes:
+        name = BaseProtocol.artifact_name(name)
+
         with path.open("rb") as f:
             body = compress(f.read(), compression)
 
@@ -71,7 +73,7 @@ class _Artifact:
         name_size, content_size = struct.unpack(cls._header_format, b[: cls._header_size])
         offset = cls._header_size
 
-        name = (b[offset : offset + name_size]).decode()
+        name = BaseProtocol.artifact_name((b[offset : offset + name_size]).decode())
         offset += name_size
 
         content = b[offset : offset + content_size]
@@ -242,6 +244,8 @@ class _Body:
         Walks the per-artifact ``(name_size, content_size)`` headers, reads the names, and seeks
         past the content bytes — never decompressing or decoding the metadata, model, or artifact
         contents. Cheapest possible introspection.
+
+        :raises UnsafeArtifactName: When an entry's name is not a plain file name.
         """
         meta_size, model_size, artifacts_count, _artifacts_size = struct.unpack(
             cls._header_format, f.read(cls._header_size)
@@ -251,7 +255,7 @@ class _Body:
         names: list[str] = []
         for _ in range(artifacts_count):
             name_size, content_size = struct.unpack(_Artifact._header_format, f.read(_Artifact._header_size))
-            names.append(f.read(name_size).decode())
+            names.append(BaseProtocol.artifact_name(f.read(name_size).decode()))
             f.seek(content_size, 1)
 
         return tuple(names)
@@ -274,6 +278,7 @@ class Protocol(BaseProtocol):
         :param compression: Compression format name applied uniformly to every section.
         :param kwargs: Forwarded to the framework-specific serializer.
         :return: Total number of body bytes written to *f*.
+        :raises UnsafeArtifactName: If a bundled artifact name is not a plain file name.
         :raises UnsupportedProtocol: If *m*'s shape is not representable in v1 (directory source).
         """
         return _Body.pack(m, f, compression=compression, **kwargs)
@@ -292,6 +297,7 @@ class Protocol(BaseProtocol):
         :param compression: Compression format used when packing.
         :return: Reconstructed :class:`ModelArtifact`. The returned artifact's :attr:`directory`
             field owns a temp directory kept alive for as long as the artifact is referenced.
+        :raises UnsafeArtifactName: If a bundled artifact name is not a plain file name.
         """
         artifact = _Body.unpack(f, compression=compression, **kwargs)
 
@@ -304,5 +310,8 @@ class Protocol(BaseProtocol):
         return _Body.unpack_meta(f, compression=compression)
 
     def manifest(self, f: t.BinaryIO, /, *, compression: types.SerializationCompression, **kwargs) -> tuple[str, ...]:
-        """Read the bundled artifact names from *f*."""
+        """Read the bundled artifact names from *f*.
+
+        :raises UnsafeArtifactName: If a bundled artifact name is not a plain file name.
+        """
         return _Body.unpack_manifest(f, compression=compression)

--- a/flama/serialize/protocols/v2.py
+++ b/flama/serialize/protocols/v2.py
@@ -20,7 +20,7 @@ Wire layout::
         artifact * count
             name_size          I
             content_size       Q
-            name               utf-8 bytes
+            name               utf-8 bytes (a single plain file name)
             content            payload bytes
     model section
         compression            B
@@ -190,7 +190,10 @@ class _Artifact:
         :param name: Name to record on the wire.
         :param path: Source file to read and compress.
         :return: Wire frame: ``(name_size, content_size, name, compressed content)``.
+        :raises UnsafeArtifactName: When *name* is not a plain file name.
         """
+        name = BaseProtocol.artifact_name(name)
+
         with path.open("rb") as f:
             body = self._compression.compress(f.read())
 
@@ -200,11 +203,12 @@ class _Artifact:
         """Unpack a single artifact entry from *b* into *directory*.
 
         :return: Tuple of the materialised path and the number of bytes consumed from *b*.
+        :raises UnsafeArtifactName: When the entry's name is not a plain file name.
         """
         name_size, content_size = struct.unpack(self._header_format, b[: self._header_size])
         offset = self._header_size
 
-        name = b[offset : offset + name_size].decode()
+        name = BaseProtocol.artifact_name(b[offset : offset + name_size].decode())
         offset += name_size
 
         content = b[offset : offset + content_size]
@@ -403,6 +407,8 @@ class _Body:
         Walks the artifacts section header (compression byte + count) and the per-entry headers to
         collect names, seeking past each content payload — never decompressing or decoding any
         metadata, model body, or artifact payload. Cheapest possible introspection.
+
+        :raises UnsafeArtifactName: When an entry's name is not a plain file name.
         """
         meta_size, _artifacts_size, _model_size = struct.unpack(self._header_format, f.read(self._header_size))
         f.seek(meta_size, 1)
@@ -412,7 +418,7 @@ class _Body:
         names: list[str] = []
         for _ in range(count):
             name_size, content_size = struct.unpack(_Artifact._header_format, f.read(_Artifact._header_size))
-            names.append(f.read(name_size).decode())
+            names.append(BaseProtocol.artifact_name(f.read(name_size).decode()))
             f.seek(content_size, 1)
 
         return tuple(names)
@@ -438,6 +444,7 @@ class Protocol(BaseProtocol):
         :param kwargs: Forwarded to the framework-specific serializer (and the per-section
             compression overrides above).
         :return: Total number of body bytes written to *f*.
+        :raises UnsafeArtifactName: If a bundled artifact name is not a plain file name.
         :raises UnsupportedProtocol: If *m*'s kind / source pair has no v2 wire encoding.
         """
         return _Body(compression).pack(m, f, **kwargs)
@@ -457,6 +464,7 @@ class Protocol(BaseProtocol):
             byte resolves to ``"inherit"``).
         :return: Reconstructed :class:`ModelArtifact`. The returned artifact's :attr:`directory`
             field owns a temp directory kept alive for as long as the artifact is referenced.
+        :raises UnsafeArtifactName: If a bundled artifact name is not a plain file name.
         """
         artifact = _Body(compression).unpack(f, **kwargs)
 
@@ -469,5 +477,8 @@ class Protocol(BaseProtocol):
         return _Body(compression).unpack_meta(f)
 
     def manifest(self, f: t.BinaryIO, /, *, compression: types.SerializationCompression, **kwargs) -> tuple[str, ...]:
-        """Read the bundled artifact names from *f*."""
+        """Read the bundled artifact names from *f*.
+
+        :raises UnsafeArtifactName: If a bundled artifact name is not a plain file name.
+        """
         return _Body(compression).unpack_manifest(f)

--- a/lib/core/src/compression.rs
+++ b/lib/core/src/compression.rs
@@ -6,7 +6,7 @@
 //! abstraction so that adding or changing a backend only requires editing the [`Encoder`]
 //! enum.
 
-use ::tar::{Archive, Builder};
+use ::tar::{Archive, Builder, EntryType};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict};
@@ -543,21 +543,26 @@ fn tar(directory: &str, writer: Py<PyAny>, format: Option<&str>) -> PyResult<usi
     Ok(py_writer.written)
 }
 
-/// Walk *archive* and unpack every entry into *dir*, skipping unsafe paths.
+/// Walk *archive* and unpack every entry into *dir*, skipping unsafe entries.
 ///
-/// Sets ``overwrite=true`` on *archive* so existing files in *dir* are replaced; entries
-/// with absolute paths or ``..`` components are skipped, mirroring ``tarfile``'s
-/// ``filter="data"`` policy. Errors are prefixed with *context* so the call site shows up in
-/// the bridged Python exception.
+/// Sets ``overwrite=true`` on *archive* so existing files in *dir* are replaced. Entries are
+/// dropped rather than rewritten when they carry an absolute path, a ``..`` component, or a link
+/// (symbolic or hard) — mirroring ``tarfile``'s ``filter="data"`` policy. Survivors are written
+/// through [`Entry::unpack_in`] rather than [`Entry::unpack`] so the write is confined to *dir*
+/// even if a previously extracted path turns out to be a symlink. Errors are prefixed with
+/// *context* so the call site shows up in the bridged Python exception.
 fn unpack_entries<R: Read>(mut archive: Archive<R>, dir: &Path, context: &'static str) -> PyResult<()> {
     archive.set_overwrite(true);
     for entry in archive.entries().map_err(map_io(context))? {
         let mut entry = entry.map_err(map_io(context))?;
+        if matches!(entry.header().entry_type(), EntryType::Symlink | EntryType::Link) {
+            continue;
+        }
         let path = entry.path().map_err(map_io(context))?.into_owned();
         if path.is_absolute() || path.components().any(|c| matches!(c, Component::ParentDir)) {
             continue;
         }
-        entry.unpack(dir.join(&path)).map_err(map_io(context))?;
+        entry.unpack_in(dir).map_err(map_io(context))?;
     }
     Ok(())
 }
@@ -565,8 +570,8 @@ fn unpack_entries<R: Read>(mut archive: Archive<R>, dir: &Path, context: &'stati
 /// Extract a tar archive from *data* into *directory*.
 ///
 /// When *format* is ``None`` *data* is treated as raw tar; otherwise it is first
-/// decompressed using the matching decoder. Entries with absolute paths or ``..``
-/// components are skipped, mirroring ``tarfile``'s ``filter="data"``.
+/// decompressed using the matching decoder. Link entries and entries with absolute paths or
+/// ``..`` components are skipped, mirroring ``tarfile``'s ``filter="data"``.
 #[pyfunction]
 #[pyo3(signature = (data, directory, format=None))]
 fn untar(data: &[u8], directory: &str, format: Option<&str>) -> PyResult<()> {
@@ -599,8 +604,8 @@ fn untar(data: &[u8], directory: &str, format: Option<&str>) -> PyResult<()> {
 /// stream terminator; callers that care about the file position past this call should
 /// ``seek`` explicitly.
 ///
-/// Entries with absolute paths or ``..`` components are skipped, mirroring [`untar`]'s
-/// safety policy.
+/// Link entries and entries with absolute paths or ``..`` components are skipped, mirroring
+/// [`untar`]'s safety policy.
 ///
 /// :param reader: A Python file-like object exposing ``.read(size)`` returning ``bytes``.
 /// :param directory: Filesystem path of the output directory.

--- a/tests/unit/cli/commands/test_get.py
+++ b/tests/unit/cli/commands/test_get.py
@@ -8,6 +8,7 @@ import pytest
 from click.testing import CliRunner
 
 from flama._cli.commands.get import _Downloader, _HuggingFaceDownloader, _RetryPolicy, command
+from flama.serialize.exceptions import UnsafeArtifactPath
 
 
 def _make_response(*, pipeline_tag: str | None = "text-generation", files=(("config.json", 12),)) -> MagicMock:
@@ -267,6 +268,30 @@ class TestCaseHuggingFaceDownloader:
                 assert downloader.retry.await_count == 1
                 ((fn,), _) = downloader.retry.await_args
                 assert callable(fn)
+
+    @pytest.mark.parametrize(
+        ["filename", "exception"],
+        [
+            pytest.param("config.json", None, id="plain-name"),
+            pytest.param("nested/config.json", None, id="nested-name"),
+            pytest.param("../escaped.bin", UnsafeArtifactPath, id="traversal"),
+            pytest.param("/tmp/escaped.bin", UnsafeArtifactPath, id="absolute"),
+        ],
+        indirect=["exception"],
+    )
+    async def test__download_file_confines_destination(
+        self, make_downloader: t.Callable[..., _HuggingFaceDownloader], filename: str, exception
+    ) -> None:
+        """Remote listings are attacker-controlled, so destinations stay under the staging root."""
+        with patch("flama._cli.commands.get.Client", return_value=_make_client(_make_response(files=[]), MagicMock())):
+            downloader = make_downloader(max_concurrent=2)
+            async with downloader:
+                downloader.retry = AsyncMock()  # type: ignore[assignment]
+
+                with exception:
+                    await downloader._download_file(filename, MagicMock(), 0)
+
+                assert downloader.retry.await_count == (0 if exception else 1)
 
     async def test__download_file_respects_concurrency_cap(
         self, make_downloader: t.Callable[..., _HuggingFaceDownloader]

--- a/tests/unit/serialize/protocols/test_base.py
+++ b/tests/unit/serialize/protocols/test_base.py
@@ -1,7 +1,31 @@
 import pytest
 
+from flama.serialize.exceptions import UnsafeArtifactName
 from flama.serialize.protocols import v1, v2
+from flama.serialize.protocols._base import BaseProtocol
 from flama.serialize.protocols._base import Protocol as ProtocolFactory
+
+
+class TestCaseBaseProtocol:
+    @pytest.mark.parametrize(
+        ["name", "exception"],
+        [
+            pytest.param("sidecar.json", None, id="plain-name"),
+            pytest.param("", UnsafeArtifactName, id="empty"),
+            pytest.param(".", UnsafeArtifactName, id="current-directory"),
+            pytest.param("..", UnsafeArtifactName, id="parent-directory"),
+            pytest.param("/tmp/escaped.bin", UnsafeArtifactName, id="absolute-posix"),
+            pytest.param("../../escaped.bin", UnsafeArtifactName, id="traversal"),
+            pytest.param("nested/sidecar.json", UnsafeArtifactName, id="nested"),
+            pytest.param("nested\\sidecar.json", UnsafeArtifactName, id="windows-separator"),
+            pytest.param("C:escaped.bin", UnsafeArtifactName, id="windows-drive"),
+            pytest.param("escaped\x00.bin", UnsafeArtifactName, id="nul-byte"),
+        ],
+        indirect=["exception"],
+    )
+    def test_artifact_name(self, name: str, exception) -> None:
+        with exception:
+            assert BaseProtocol.artifact_name(name) == name
 
 
 class TestCaseProtocolFactory:

--- a/tests/unit/serialize/protocols/test_v1.py
+++ b/tests/unit/serialize/protocols/test_v1.py
@@ -11,7 +11,7 @@ from flama._core.compression import compress
 from flama._core.json_encoder import encode_json
 from flama.serialize import data_structures
 from flama.serialize.data_structures import FrameworkInfo, Metadata, ModelArtifact, ModelDirectory, ModelInfo
-from flama.serialize.exceptions import UnsupportedProtocol
+from flama.serialize.exceptions import UnsafeArtifactName, UnsupportedProtocol
 from flama.serialize.protocols import v1
 
 
@@ -32,6 +32,34 @@ class TestCaseV1Artifact:
 
         assert path.read_bytes() == content
         assert size == len(packed)
+
+    @pytest.mark.parametrize(
+        ["template", "exception"],
+        [
+            pytest.param("sidecar.json", None, id="plain-name"),
+            pytest.param("{escape}", UnsafeArtifactName, id="absolute"),
+            pytest.param("../escaped.bin", UnsafeArtifactName, id="traversal"),
+            pytest.param("nested/escaped.bin", UnsafeArtifactName, id="nested"),
+        ],
+        indirect=["exception"],
+    )
+    def test_unpack_rejects_unsafe_name(
+        self, compression_format: str, tmp_path: pathlib.Path, template: str, exception
+    ) -> None:
+        """A hand-crafted entry cannot materialise outside the extraction directory (``CWE-22``)."""
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        escape = tmp_path / "escaped.bin"
+        name = template.format(escape=escape)
+        content = compress(b"escaped", compression_format)
+        frame = struct.pack(v1._Artifact._header_format, len(name), len(content)) + name.encode() + content
+
+        with exception:
+            path, _consumed = v1._Artifact.unpack(frame, compression=compression_format, directory=out_dir)
+
+        assert not escape.exists()
+        if not exception:
+            assert path.read_bytes() == b"escaped"
 
 
 @pytest.fixture(scope="function")
@@ -137,6 +165,31 @@ class TestCaseV1Body:
             v1._Body.pack(ma, buf, compression=compression_format)
         assert excinfo.value.protocol == 1
         assert "directory path" in excinfo.value.reason
+
+    @pytest.mark.parametrize(
+        ["name", "exception"],
+        [
+            pytest.param("extra.bin", None, id="plain-name"),
+            pytest.param("../escaped.bin", UnsafeArtifactName, id="traversal"),
+        ],
+        indirect=["exception"],
+    )
+    def test_unpack_manifest(self, compression_format: str, name: str, exception) -> None:
+        """Manifest names reach callers (and API responses) verbatim, so they are validated too."""
+        meta_bytes = compress(b"{}", compression_format)
+        entry = struct.pack(v1._Artifact._header_format, len(name), 0) + name.encode()
+
+        buf = io.BytesIO()
+        buf.write(struct.pack(v1._Body._header_format, len(meta_bytes), 0, 1, len(entry)))
+        buf.write(meta_bytes)
+        buf.write(entry)
+        buf.seek(0)
+
+        with exception:
+            names = v1._Body.unpack_manifest(buf, compression=compression_format)
+
+        if not exception:
+            assert names == (name,)
 
 
 class TestCaseV1Protocol:

--- a/tests/unit/serialize/protocols/test_v2.py
+++ b/tests/unit/serialize/protocols/test_v2.py
@@ -19,7 +19,12 @@ from flama.serialize.data_structures import (
     ModelDirectory,
     ModelInfo,
 )
-from flama.serialize.exceptions import UnknownCompression, UnknownModelKind, UnsupportedProtocol
+from flama.serialize.exceptions import (
+    UnknownCompression,
+    UnknownModelKind,
+    UnsafeArtifactName,
+    UnsupportedProtocol,
+)
 from flama.serialize.protocols import v2
 
 SECTION_COMPRESSIONS = [
@@ -146,6 +151,32 @@ class TestCaseArtifact:
 
         assert path.read_bytes() == content
         assert size == len(packed)
+
+    @pytest.mark.parametrize(
+        ["template", "exception"],
+        [
+            pytest.param("sidecar.json", None, id="plain-name"),
+            pytest.param("{escape}", UnsafeArtifactName, id="absolute"),
+            pytest.param("../escaped.bin", UnsafeArtifactName, id="traversal"),
+            pytest.param("nested/escaped.bin", UnsafeArtifactName, id="nested"),
+        ],
+        indirect=["exception"],
+    )
+    def test_unpack_rejects_unsafe_name(self, tmp_path: pathlib.Path, template: str, exception) -> None:
+        """A hand-crafted entry cannot materialise outside the extraction directory (``CWE-22``)."""
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        escape = tmp_path / "escaped.bin"
+        name = template.format(escape=escape)
+        content = b"escaped"
+        frame = struct.pack(v2._Artifact._header_format, len(name), len(content)) + name.encode() + content
+
+        with exception:
+            path, _consumed = v2._Artifact(v2._Compression(None)).unpack(frame, directory=out_dir)
+
+        assert not escape.exists()
+        if not exception:
+            assert path.read_bytes() == content
 
 
 class TestCaseBody:
@@ -302,6 +333,31 @@ class TestCaseBody:
         buf.seek(0)
         names = v2._Body(compression_format).unpack_manifest(buf)
         assert names == ("extra.bin",)
+
+    @pytest.mark.parametrize(
+        ["exception"],
+        [pytest.param(UnsafeArtifactName, id="unsafe-artifact-name")],
+        indirect=["exception"],
+    )
+    def test_unpack_manifest_rejects_unsafe_name(self, compression_format: str, exception) -> None:
+        """Manifest names reach callers (and API responses) verbatim, so they are validated too."""
+        name = "../escaped.bin"
+        passthrough_byte = v2._Compression._NAME_TO_BYTE[None]
+        meta_bytes = struct.pack(v2._Body._meta_header_format, passthrough_byte) + b"{}"
+        artifacts_bytes = (
+            struct.pack(v2._Body._artifacts_header_format, passthrough_byte, 1)
+            + struct.pack(v2._Artifact._header_format, len(name), 0)
+            + name.encode()
+        )
+
+        buf = io.BytesIO()
+        buf.write(struct.pack(v2._Body._header_format, len(meta_bytes), len(artifacts_bytes), 0))
+        buf.write(meta_bytes)
+        buf.write(artifacts_bytes)
+        buf.seek(0)
+
+        with exception:
+            v2._Body(compression_format).unpack_manifest(buf)
 
     @pytest.mark.parametrize(
         ["exception"],

--- a/tests/unit/test_compression.py
+++ b/tests/unit/test_compression.py
@@ -1,5 +1,6 @@
 import io
 import pathlib
+import tarfile
 
 import pytest
 
@@ -115,6 +116,33 @@ class TestCaseTar:
         assert (dst / "a.txt").read_text() == "hello"
         assert (dst / "sub" / "b.txt").read_text() == "world"
         assert not (dst / ".hidden.txt").exists()
+
+    def test_untar_skips_unsafe_entries(self, tmp_path: pathlib.Path) -> None:
+        """Traversal, absolute and link entries are dropped instead of written (``CWE-22``)."""
+        escape = tmp_path / "escaped.txt"
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w") as archive:
+            for name, payload in (("../escaped.txt", b"escaped"), ("/escaped.txt", b"escaped"), ("a.txt", b"hello")):
+                info = tarfile.TarInfo(name)
+                info.size = len(payload)
+                archive.addfile(info, io.BytesIO(payload))
+
+            link = tarfile.TarInfo("link")
+            link.type = tarfile.SYMTYPE
+            link.linkname = str(tmp_path)
+            archive.addfile(link)
+
+            through = tarfile.TarInfo("link/escaped.txt")
+            through.size = len(b"escaped")
+            archive.addfile(through, io.BytesIO(b"escaped"))
+
+        dst = tmp_path / "dst"
+        untar(buf.getvalue(), str(dst), format=None)
+
+        assert (dst / "a.txt").read_text() == "hello"
+        assert not escape.exists()
+        assert not (dst / "escaped.txt").exists()
+        assert not (dst / "link").is_symlink()
 
     def test_untar_from_advances_only_within_length(self, directory: pathlib.Path, tmp_path: pathlib.Path) -> None:
         body = io.BytesIO()


### PR DESCRIPTION
Fixes the arbitrary file write reported in [GHSA-65hp-c8p8-8r24](https://github.com/vortico/flama/security/advisories/GHSA-65hp-c8p8-8r24) (CWE-22, "zip-slip"). Artifact names were decoded from a `.flm` body and joined straight onto the extraction directory, so an absolute or `../` name let a crafted artifact write anywhere the loading process could reach.

## The fix

`BaseProtocol.artifact_name()` accepts only a single plain file name and rejects absolute paths, `..` traversal segments, nested names, Windows drive-relative names, empty names and names containing NUL with a new `UnsafeArtifactName`. Names are checked under both POSIX and Windows path semantics, so an artifact authored on one platform cannot escape on the other. The relative directory names are rejected explicitly because `pathlib` keeps `".."` as an ordinary final component rather than normalising it away.

Validation is applied at every point where a name crosses the trust boundary, in **both** protocol versions:

- `_Artifact.unpack` — the reported sink. The report covers v2 only, but v1 carried the identical join and is reachable just by declaring `protocol_version = 1` in the file header, so a v2-only fix would have left the vulnerability fully exploitable.
- `_Artifact.pack` — so Flama cannot be used to author a malicious artifact. The published proof of concept used Flama's own `_Body.pack` as its encoder.
- `unpack_manifest` — its output is returned to callers and surfaced over HTTP through the model `inspect` endpoint.

Restricting names to a single component is not a functional regression: nested names never round-tripped, because extraction did not create intermediate directories, so `path.open("wb")` raised `FileNotFoundError` for any name containing a separator. Keeping names flat also leaves the `artifacts` mapping unambiguously keyed, since both protocols key it by file name.

## Related hardening

Two adjacent instances of the same class of defect, neither part of the report:

- `flama get` joined the remote listing's `rfilename` onto its staging directory with `mkdir(parents=True)`. Since anyone can publish a repository and the user names it, that input is attacker-controlled. Nested names are legitimate here, so the destination is confined by containment (`UnsafeArtifactPath`) rather than by the single-component rule.
- Tar extraction in `flama._core` wrote entries with `Entry::unpack`, which performs no containment or symlink check, so a bundle carrying a symlink entry followed by a file beneath it could redirect the write. Entries are now written with `Entry::unpack_in` and link entries are skipped outright. The explicit absolute/`..` filter is kept rather than delegated to `unpack_in`, because `unpack_in` silently *rebases* an absolute entry into the target instead of skipping it — which would let a bundle's `/config.json` overwrite its real `config.json`.

## Threat model

Worth stating explicitly, as the advisory now does: this patch does not make untrusted `.flm` files safe to load. The model section is unpickled by the sklearn and PyTorch serialisers, so loading an artifact from an untrusted source is equivalent to running that publisher's code. `SECURITY.md` now documents this.

## Test plan

- [x] `TestCaseBaseProtocol.test_artifact_name` covers the accepted name plus nine rejected shapes (empty, `.`, `..`, absolute, traversal, nested, Windows separator, Windows drive, NUL).
- [x] `test_unpack_rejects_unsafe_name` in both `test_v1.py` and `test_v2.py` hand-crafts a wire frame (necessary now that `pack` validates) and asserts the escape target does not exist on disk, not merely that an exception was raised.
- [x] `test_unpack_manifest_rejects_unsafe_name` (v2) and a parametrised `test_unpack_manifest` (v1, previously untested).
- [x] `test__download_file_confines_destination` covers the `flama get` guard, including the nested name that must still be allowed.
- [x] `test_untar_skips_unsafe_entries` builds a hostile tar with traversal, absolute, symlink and write-through-symlink entries.
- [x] Full suite green (5915 passed), coverage 99.77%, `ruff`, `ty`, `cargo clippy` and `cargo fmt` clean.