### PR TITLE
:wrench: Declare LICENSE as a license file for packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 name = "flama"
 version = "2.0.8"
 description = "Fire up your models with the flame 🔥"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 readme = "README.md"
 authors = [
   { name = "José Antonio Perdiguero López", email = "perdy@perdy.io" },


### PR DESCRIPTION
The 2.0.7 and 2.0.8 source distributions were rejected by PyPI, in both cases *after* all 35 wheels had already been uploaded:

```
400 License-File LICENSE does not exist in distribution file flama-2.0.8.tar.gz at flama-2.0.8/LICENSE
```

## Cause

Not a regression in our toolchain. maturin has emitted `Metadata-Version: 2.4` with `License-File: LICENSE` for a while without including the file — the last accepted sdist, `flama-2.0.6.tar.gz`, carries exactly the same broken metadata and no `LICENSE`. What changed is that **PyPI turned on the PEP 639 validation** that rejects an sdist whose `License-File` entries are absent from the archive, somewhere between the 2.0.6 upload (24 Jun) and the 2.0.7 upload (27 Jul).

So there is nothing to revert; the file has to actually be shipped.

## Fix

Declaring `license-files` is enough for maturin to include the file in the sdist — no `[tool.maturin] include` entry is needed. Switching to the SPDX string form at the same time replaces the deprecated PEP 621 `license = { text = ... }` table with a proper `License-Expression` field. There is no `License ::` trove classifier in `classifiers`, so there is no classifier/expression conflict to worry about.

## Verification

Built locally from this branch:

```
Metadata-Version: 2.4
License-File: LICENSE
License-Expression: Apache-2.0
```

- `flama-2.0.8/LICENSE` is present in the tarball and contains the Apache 2.0 text.
- `twine check --strict` passes.
- The archive file list is identical to the last accepted sdist (`flama-2.0.6.tar.gz`) apart from the added `LICENSE` — the diff is a single line. `benchmarks/` and `flama/_templates/` remain excluded, the eight Rust sources remain included.
- `uv lock --check` is clean; no dependency resolution change.

## Notes

`:wrench:` is deliberate: it is absent from the release rules in `release.config.js`, so this lands without cutting a version. 2.0.8 keeps its 35 published wheels, and the missing `flama-2.0.8.tar.gz` is uploaded separately — the filename was never stored, so PyPI accepts it.

A CI guard for this class of failure is deferred. Worth noting for whoever picks it up that `twine check` does **not** cover it (it validates metadata parsing and README rendering only); the check has to cross-reference `PKG-INFO`'s `License-File` entries against the archive contents. Placing it in `build-sdist` would turn a half-published release into a clean no-publish, since `publish` depends on that job.